### PR TITLE
Add info about what each Silly Tech Building enables.

### DIFF
--- a/Rules/Factories.yaml
+++ b/Rules/Factories.yaml
@@ -1509,7 +1509,7 @@ SILLYFACT4:
 	ProvidesPrerequisite:
 		Prerequisite: vehicleproduction
 	Tooltip:
-		Name: Heavy Anti-Air Platform Factory
+		Name: Anti-Air Platform Factory
 	Buildable:
 		BuildDuration: 300
 		BuildPaletteOrder: 420

--- a/Rules/Techbuildings.yaml
+++ b/Rules/Techbuildings.yaml
@@ -957,7 +957,7 @@ SILLYONE:
 		Prerequisites: forb, fammo, !sillyone, ~!tech0, ~!tech1, ~!tech2, ~!tech3, ~!tech4, ~!tech5, ~!tech6, ~!tech7, ~!tech8, ~!tech9, ~!tech10, ~!tech11, ~!tech12, ~!tech13, ~!tech14, ~!tech15
 		Queue: Defenses.Fact
 		BuildLimit: 1 
-		Description: Enables Silly Technology!
+		Description: Enables:\n  Flying Cruiser\n  Harvester
 		IconPalette: ra
 	Building:
 		Footprint: xx xx ==
@@ -998,7 +998,7 @@ SILLYTWO:
 		Queue: Defenses.Fact
 		BuildLimit: 1 
 		IconPalette: ra
-		Description: Attention! Level gets more Dangerous!
+		Description: Enables:\n  Rocket Bomber\n  Anti-Air Platform
 	Building:
 		Footprint: ___ xxx xx= ===
 		Dimensions: 3,4
@@ -1041,7 +1041,7 @@ SILLYTHREE:
 		Queue: Defenses.Fact
 		BuildLimit: 1 
 		IconPalette: ra
-		Description: Attention! Level gets more Dangerous!
+		Description: Enables:\n  Submarine\n  Landing Craft
 	Building:
 		Footprint: xx ==
 		Dimensions: 2,2


### PR DESCRIPTION
Also removed `Heavy` in `Heavy Anti-Air Platform Factory`, unit is just called `Anti-Air Platform`.